### PR TITLE
include URL in error messages

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -131,7 +131,7 @@ def go():
                     l = parse_html(r.read())
                     break
                 except Exception as e:
-                    print '!!!/\/\/\!!! ERROR %s !!!/\/\/\!!!' % e
+                    print '!!!/\/\/\!!! ERROR %s (url: %s) !!!/\/\/\!!!' % (e, url)
                     try:
                         code = e.code
                     except:


### PR DESCRIPTION
to help troubleshooting in cases when verbose output is off, which is default